### PR TITLE
Add OpalOPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A curated list of tools related to Industrial Control System (ICS) security and 
 * ntopng (community version) - a web-based network traffic monitoring application released under GPLv3. Supports Industrial IOT and Scada with modbus, DNP3 and IEC 60870-5-104 since ntopng 4.2 (October 2020)
 * Sequence 2 Sequence Anomaly Detection on SWaT - Anomaly Detection for SWaT Dataset using Sequence-to-Sequence Neural Networks
 * Poisoning ICS Attack Detectors - Poisoning Attacks on Cyber Attack Detectors for Industrial Control Systems -- operates on the SWaT dataset
+* [OpalOPC](https://opalopc.com/) - An OPC UA vulnerability and misconfiguration scanner
 
 
 


### PR DESCRIPTION
OpalOPC is a vulnerability scanner developed by myself. It targets the OT protocol OPC UA.

It is free for non-commercial use.